### PR TITLE
Revert "Bump tomcat-embed-core from 8.5.23 to 8.5.63 in /2021-2022/first-term/internet-programming/servlet-timer"

### DIFF
--- a/2021-2022/first-term/internet-programming/servlet-timer/pom.xml
+++ b/2021-2022/first-term/internet-programming/servlet-timer/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <tomcat.version>8.5.63</tomcat.version>
+        <tomcat.version>8.5.23</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Reverts krispetrov/tues#2